### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,6 +19,8 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
     - name: Set version
       run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }}
+    - name: Run tests
+      run: mvn --batch-mode test
     - name: Publish package
       run: mvn --batch-mode deploy -DskipTests
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
+.idea/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/README.md
+++ b/README.md
@@ -1,68 +1,6 @@
 # JProblem
 
-A simple Java library for helpful exception messages
-
-Feel free to leave an issue or make pull requests
-
-## Example
-
-You could use class `DefaultProblemBuilder` to build some `Problem` and throw it as `IllegalArgumentException` or any other
-
-```java
-throw DefaultProblemBuilder.newBuilder()
-        .id(() -> "Example ID, provide ID that will help you to identify a problem")
-        .what("Test JProblem") //required
-        .where("Just in main class")
-        .why("I want to show how to use JProblem")
-        .documentedAt("https://github.com/xeruvimov/jproblem")
-        .withLongDescription("Use this field to provide long description of error; you may need to write some context or anything else")
-        .addSolution("Use JProblem to write code that works as indeed")
-        .addSolution("Or just ignore this exception")
-        .cause(e)
-        .buildAsException(IllegalArgumentException::new);
-```
-
-The code above will produce next exception in console
-
-```text
-Exception in thread "main" java.lang.IllegalArgumentException: A problem happened
-
-Problem ID : Example ID, provide ID that will help you to identify a problem
-
-Where? : Just in main class
-
-What? : Test JProblem
-
-Why? : I want to show how to use JProblem
-
-Long description : Use this field to provide long description of error; you may need to write some context or anything else
-
-Possible solutions : 
-    - Use JProblem to write code that works as indeed
-    - Or just ignore this exception
-
-Documentation link : https://github.com/xeruvimov/jproblem
-	at io.github.xeruvimov.jproblem.builder.DefaultProblemBuilder.buildAsException(DefaultProblemBuilder.java:91)
-	at com.skheruvimov.script.ScriptTestProjApp.main(ScriptTestProjApp.java:30)
-Caused by: java.lang.RuntimeException: Root cause
-	at com.skheruvimov.script.ScriptTestProjApp.main(ScriptTestProjApp.java:18)
-```
----
-**_Only `what` field is required_**, so you also can make small messages
-
-```java
-throw DefaultProblemBuilder.newBuilder()
-        .what("I don't want to force my collegues to read 'War and Peace' in every error case")
-        .buildAsRuntimeException();
-```
-
-```text
-Exception in thread "main" java.lang.RuntimeException: A problem happened
-
-What? : I dont want to force my colleges to read 'War and Peace' in every error cases
-	at io.github.xeruvimov.jproblem.builder.DefaultProblemBuilder.buildAsRuntimeException(DefaultProblemBuilder.java:72)
-	at com.skheruvimov.script.ScriptTestProjApp.main(ScriptTestProjApp.java:20)
-```
+A small Java library for building clear, structured exception messages.
 
 ## Installation
 
@@ -70,12 +8,74 @@ What? : I dont want to force my colleges to read 'War and Peace' in every error 
 <dependency>
     <groupId>io.github.xeruvimov</groupId>
     <artifactId>jproblem</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
+```groovy
+implementation group: 'io.github.xeruvimov', name: 'jproblem', version: '1.1.0'
 ```
-implementation group: 'io.github.xeruvimov', name: 'jproblem', version: '1.0.2'
+
+## Recommended API (StrictProblemBuilder)
+
+`StrictProblemBuilder` is recommended for new code. It enforces required fields at compile time:
+- `id` is required
+- `what` is required
+
+```java
+import io.github.xeruvimov.jproblem.builder.StrictProblemBuilder;
+
+throw StrictProblemBuilder.withId("AUTH-401")
+        .what("Authorization failed")
+        .where("Auth filter")
+        .why("Access token is missing")
+        .addSolution("Provide Bearer token")
+        .documentedAt("https://example.com/docs/auth")
+        .buildAsException(IllegalArgumentException::new);
+```
+
+You can also pass `ProblemId` explicitly:
+
+```java
+import io.github.xeruvimov.jproblem.builder.StrictProblemBuilder;
+import io.github.xeruvimov.jproblem.problem.ProblemId;
+
+throw StrictProblemBuilder.withId(ProblemId.of("AUTH-401"))
+        .what("Authorization failed")
+        .buildAsRuntimeException();
+```
+
+## Legacy API (DefaultProblemBuilder)
+
+`DefaultProblemBuilder` is still supported for backward compatibility.
+For new code, prefer `StrictProblemBuilder`.
+
+```java
+import io.github.xeruvimov.jproblem.builder.DefaultProblemBuilder;
+
+throw DefaultProblemBuilder.newBuilder()
+        .id("DB-001") // also supports: id(ProblemId.of(...)) and id(() -> "...")
+        .what("Database connection failed")
+        .why("Connection pool is exhausted")
+        .addSolution("Increase pool size")
+        .buildAsRuntimeException();
+```
+
+## HTTP/JSON Friendly Single-Line Message
+
+When exception message is returned in JSON, line breaks appear as `\n`.
+Use `DefaultTextRender.compactToSingleLine(...)` to normalize a rendered message to one line:
+
+```java
+import io.github.xeruvimov.jproblem.render.DefaultTextRender;
+
+String messageForHttp = DefaultTextRender.compactToSingleLine(exception.getMessage());
+```
+
+Example output:
+
+```text
+A problem happened | Problem ID : AUTH-401 | Where? : Auth filter | What? : Authorization failed | Why? : Access token is missing
 ```
 
 ### inspired by [JDoctor](https://github.com/melix/jdoctor)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.xeruvimov</groupId>
     <artifactId>jproblem</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple Java library for helpful exception messages</description>
@@ -37,6 +37,15 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/src/main/java/io/github/xeruvimov/jproblem/builder/Builder.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/builder/Builder.java
@@ -5,26 +5,107 @@ import io.github.xeruvimov.jproblem.problem.ProblemId;
 
 import java.util.function.Function;
 
+/**
+ * Legacy fluent builder contract for constructing {@link Problem} instances.
+ * <p>
+ * For new code, prefer {@link StrictProblemBuilder} because it enforces required fields
+ * ({@code id} and {@code what}) at compile time.
+ */
 public interface Builder {
+    /**
+     * Sets problem id.
+     *
+     * @param id problem id provider
+     * @return current builder
+     */
     Builder id(ProblemId id);
 
+    /**
+     * Sets problem id using plain string value.
+     *
+     * @param id problem id
+     * @return current builder
+     */
+    default Builder id(String id) {
+        return id(() -> id);
+    }
+
+    /**
+     * Sets short problem description.
+     *
+     * @param shortDescription short problem description
+     * @return current builder
+     */
     Builder what(String shortDescription);
 
+    /**
+     * Sets reason text.
+     *
+     * @param reason reason text
+     * @return current builder
+     */
     Builder why(String reason);
 
+    /**
+     * Sets context where the problem happened.
+     *
+     * @param context context description
+     * @return current builder
+     */
     Builder where(String context);
 
+    /**
+     * Sets long problem description.
+     *
+     * @param longDescription long description
+     * @return current builder
+     */
     Builder withLongDescription(String longDescription);
 
+    /**
+     * Adds possible solution entry.
+     *
+     * @param solution solution text
+     * @return current builder
+     */
     Builder addSolution(String solution);
 
+    /**
+     * Sets documentation link.
+     *
+     * @param link documentation link
+     * @return current builder
+     */
     Builder documentedAt(String link);
 
+    /**
+     * Sets root cause throwable.
+     *
+     * @param cause root cause
+     * @return current builder
+     */
     Builder cause(Throwable cause);
 
+    /**
+     * Builds problem object.
+     *
+     * @return constructed problem
+     */
     Problem build();
 
+    /**
+     * Builds a {@link RuntimeException} with rendered problem text.
+     *
+     * @return runtime exception
+     */
     RuntimeException buildAsRuntimeException();
 
+    /**
+     * Builds custom exception with rendered problem text.
+     *
+     * @param exception exception factory
+     * @param <T> exception type
+     * @return exception instance
+     */
     <T extends Exception> T buildAsException(Function<String, T> exception);
 }

--- a/src/main/java/io/github/xeruvimov/jproblem/builder/DefaultProblemBuilder.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/builder/DefaultProblemBuilder.java
@@ -9,6 +9,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * Default legacy {@link Builder} implementation.
+ * <p>
+ * For new code, prefer {@link StrictProblemBuilder} because it makes required fields
+ * mandatory at compile time.
+ */
 public class DefaultProblemBuilder implements Builder {
     private final ProblemData problemData;
 
@@ -16,6 +22,11 @@ public class DefaultProblemBuilder implements Builder {
         this.problemData = new ProblemData();
     }
 
+    /**
+     * Creates new legacy builder instance.
+     *
+     * @return builder instance
+     */
     public static Builder newBuilder() {
         return new DefaultProblemBuilder();
     }

--- a/src/main/java/io/github/xeruvimov/jproblem/builder/StrictProblemBuilder.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/builder/StrictProblemBuilder.java
@@ -1,0 +1,137 @@
+package io.github.xeruvimov.jproblem.builder;
+
+import io.github.xeruvimov.jproblem.problem.BaseProblem;
+import io.github.xeruvimov.jproblem.problem.Problem;
+import io.github.xeruvimov.jproblem.problem.ProblemId;
+import io.github.xeruvimov.jproblem.render.DefaultTextRender;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Type-safe staged builder that forces users to provide problem id and short description
+ * before build methods become available.
+ */
+public final class StrictProblemBuilder {
+
+    private StrictProblemBuilder() {
+    }
+
+    public static WhatStep withId(String id) {
+        return withId(ProblemId.of(Objects.requireNonNull(id, "id must not be null")));
+    }
+
+    public static WhatStep withId(ProblemId id) {
+        StrictBuilder builder = new StrictBuilder();
+        builder.problemData.id = Objects.requireNonNull(id, "id must not be null");
+        return builder;
+    }
+
+    public interface WhatStep {
+        OptionalStep what(String shortDescription);
+    }
+
+    public interface OptionalStep {
+        OptionalStep why(String reason);
+
+        OptionalStep where(String context);
+
+        OptionalStep withLongDescription(String longDescription);
+
+        OptionalStep addSolution(String solution);
+
+        OptionalStep documentedAt(String link);
+
+        OptionalStep cause(Throwable cause);
+
+        Problem build();
+
+        RuntimeException buildAsRuntimeException();
+
+        <T extends Exception> T buildAsException(Function<String, T> exception);
+    }
+
+    private static final class StrictBuilder implements WhatStep, OptionalStep {
+        private final ProblemData problemData = new ProblemData();
+
+        @Override
+        public OptionalStep what(String shortDescription) {
+            problemData.shortDescription = Objects.requireNonNull(shortDescription, "shortDescription must not be null");
+            return this;
+        }
+
+        @Override
+        public OptionalStep why(String reason) {
+            problemData.reason = reason;
+            return this;
+        }
+
+        @Override
+        public OptionalStep where(String context) {
+            problemData.context = context;
+            return this;
+        }
+
+        @Override
+        public OptionalStep withLongDescription(String longDescription) {
+            problemData.longDescription = longDescription;
+            return this;
+        }
+
+        @Override
+        public OptionalStep addSolution(String solution) {
+            problemData.solutions.add(solution);
+            return this;
+        }
+
+        @Override
+        public OptionalStep documentedAt(String link) {
+            problemData.link = link;
+            return this;
+        }
+
+        @Override
+        public OptionalStep cause(Throwable cause) {
+            problemData.cause = cause;
+            return this;
+        }
+
+        @Override
+        public Problem build() {
+            return new BaseProblem(problemData.id,
+                    problemData.shortDescription,
+                    problemData.longDescription,
+                    problemData.reason,
+                    problemData.solutions,
+                    problemData.link,
+                    problemData.context,
+                    problemData.cause);
+        }
+
+        @Override
+        public RuntimeException buildAsRuntimeException() {
+            return buildAsException(RuntimeException::new);
+        }
+
+        @Override
+        public <T extends Exception> T buildAsException(Function<String, T> exception) {
+            var problem = build();
+            var result = exception.apply(DefaultTextRender.render(problem));
+            problem.getCause().ifPresent(result::initCause);
+            return result;
+        }
+    }
+
+    private static final class ProblemData {
+        ProblemId id;
+        String shortDescription;
+        String reason;
+        String longDescription;
+        List<String> solutions = new ArrayList<>();
+        String link;
+        String context;
+        Throwable cause;
+    }
+}

--- a/src/main/java/io/github/xeruvimov/jproblem/problem/BaseProblem.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/problem/BaseProblem.java
@@ -4,8 +4,23 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Default immutable {@link Problem} implementation.
+ */
 public class BaseProblem implements Problem {
 
+    /**
+     * Creates immutable problem model.
+     *
+     * @param problemId problem id
+     * @param shortDescription short description (required)
+     * @param longDescription long description
+     * @param reason reason
+     * @param solutions possible solutions
+     * @param documentationLink documentation link
+     * @param context context
+     * @param cause root cause
+     */
     public BaseProblem(ProblemId problemId,
                        String shortDescription,
                        String longDescription,
@@ -18,7 +33,7 @@ public class BaseProblem implements Problem {
         this.shortDescription = Objects.requireNonNull(shortDescription, "shortDescription must not be null");
         this.longDescription = longDescription;
         this.reason = reason;
-        this.solutions = Objects.requireNonNull(solutions);
+        this.solutions = List.copyOf(Objects.requireNonNull(solutions, "solutions must not be null"));
         this.documentationLink = documentationLink;
         this.context = context;
         this.cause = cause;

--- a/src/main/java/io/github/xeruvimov/jproblem/problem/Problem.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/problem/Problem.java
@@ -4,33 +4,76 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Immutable read-only view of a problem description used for rendering and exception creation.
+ */
 public interface Problem {
+    /**
+     * Returns optional problem id.
+     *
+     * @return optional problem id
+     */
     default Optional<ProblemId> getId() {
         return Optional.empty();
     }
 
+    /**
+     * Returns short problem description.
+     *
+     * @return short description
+     */
     String getShortDescription();
 
+    /**
+     * Returns optional long description.
+     *
+     * @return optional long description
+     */
     default Optional<String> getLongDescription() {
         return Optional.empty();
     }
 
+    /**
+     * Returns optional reason.
+     *
+     * @return optional reason
+     */
     default Optional<String> getWhy() {
         return Optional.empty();
     }
 
+    /**
+     * Returns possible solutions list.
+     *
+     * @return possible solutions
+     */
     default List<String> getSolutions() {
         return Collections.emptyList();
     }
 
+    /**
+     * Returns optional documentation link.
+     *
+     * @return optional documentation link
+     */
     default Optional<String> getDocumentationLink() {
         return Optional.empty();
     }
 
+    /**
+     * Returns optional context where problem happened.
+     *
+     * @return optional context
+     */
     default Optional<String> getWhere() {
         return Optional.empty();
     }
 
+    /**
+     * Returns optional root cause throwable.
+     *
+     * @return optional cause
+     */
     default Optional<Throwable> getCause() {
         return Optional.empty();
     }

--- a/src/main/java/io/github/xeruvimov/jproblem/problem/ProblemId.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/problem/ProblemId.java
@@ -1,5 +1,23 @@
 package io.github.xeruvimov.jproblem.problem;
 
+/**
+ * Functional interface representing a problem identifier.
+ */
 public interface ProblemId {
+    /**
+     * Returns id value.
+     *
+     * @return id value
+     */
     String getId();
+
+    /**
+     * Creates problem id from plain string.
+     *
+     * @param id id value
+     * @return problem id instance
+     */
+    static ProblemId of(String id) {
+        return () -> id;
+    }
 }

--- a/src/main/java/io/github/xeruvimov/jproblem/render/DefaultTextRender.java
+++ b/src/main/java/io/github/xeruvimov/jproblem/render/DefaultTextRender.java
@@ -2,12 +2,28 @@ package io.github.xeruvimov.jproblem.render;
 
 import io.github.xeruvimov.jproblem.problem.Problem;
 
+/**
+ * Utility class for rendering {@link Problem} into human-readable text.
+ */
 public class DefaultTextRender {
 
+    /**
+     * Renders problem text with default header.
+     *
+     * @param problem problem object
+     * @return rendered text
+     */
     public static String render(Problem problem) {
         return render("A problem happened", problem);
     }
 
+    /**
+     * Renders problem text with custom header.
+     *
+     * @param header header text
+     * @param problem problem object
+     * @return rendered text
+     */
     public static String render(String header, Problem problem) {
         var sb = new StringBuilder();
         sb.append(header);
@@ -60,5 +76,27 @@ public class DefaultTextRender {
             sb.append("Documentation link : ").append(documentationLink);
         });
         return sb.toString();
+    }
+
+    /**
+     * Compacts a rendered multi-line problem text into a single line while preserving section boundaries.
+     * <p>
+     * The method treats blank lines as section separators and converts them to {@code " | "}.
+     * Single line breaks inside a section are converted to spaces, then repeated spaces are collapsed.
+     *
+     * @param renderedProblemText rendered problem text (for example, from {@link #render(Problem)})
+     * @return a normalized single-line representation convenient for HTTP JSON responses
+     */
+    public static String compactToSingleLine(String renderedProblemText) {
+        if (renderedProblemText == null) {
+            return null;
+        }
+        return renderedProblemText
+                .replace("\r\n", "\n")
+                .replace('\r', '\n')
+                .replaceAll("\\n\\s*\\n+", " | ")
+                .replace('\n', ' ')
+                .replaceAll("\\s{2,}", " ")
+                .trim();
     }
 }

--- a/src/test/java/io/github/xeruvimov/jproblem/builder/DefaultProblemBuilderTest.java
+++ b/src/test/java/io/github/xeruvimov/jproblem/builder/DefaultProblemBuilderTest.java
@@ -1,0 +1,126 @@
+package io.github.xeruvimov.jproblem.builder;
+
+import io.github.xeruvimov.jproblem.problem.Problem;
+import io.github.xeruvimov.jproblem.problem.ProblemId;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultProblemBuilderTest {
+
+    @Test
+    void idCanBeSetViaStringOverload() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .id("SIMPLE-ID")
+                .what("Failure")
+                .build();
+
+        assertTrue(problem.getId().isPresent());
+        assertEquals("SIMPLE-ID", problem.getId().get().getId());
+    }
+
+    @Test
+    void idCanBeSetViaProblemIdFactory() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .id(ProblemId.of("FACTORY-ID"))
+                .what("Failure")
+                .build();
+
+        assertTrue(problem.getId().isPresent());
+        assertEquals("FACTORY-ID", problem.getId().get().getId());
+    }
+
+    @Test
+    void buildFailsWhenShortDescriptionIsMissing() {
+        NullPointerException error = assertThrows(
+                NullPointerException.class,
+                () -> DefaultProblemBuilder.newBuilder().build()
+        );
+        assertEquals("shortDescription must not be null", error.getMessage());
+    }
+
+    @Test
+    void buildAsExceptionIncludesRenderedMessageAndCause() {
+        Throwable rootCause = new IllegalStateException("Root cause");
+        ProblemId problemId = () -> "EXAMPLE-1";
+
+        IllegalArgumentException exception = DefaultProblemBuilder.newBuilder()
+                .id(problemId)
+                .where("Request handler")
+                .what("Cannot parse payload")
+                .why("Input is malformed")
+                .withLongDescription("JSON payload contains invalid field types")
+                .addSolution("Validate payload with JSON schema before parsing")
+                .documentedAt("https://example.com/docs/payload")
+                .cause(rootCause)
+                .buildAsException(IllegalArgumentException::new);
+
+        assertSame(rootCause, exception.getCause());
+        assertTrue(exception.getMessage().contains("A problem happened"));
+        assertTrue(exception.getMessage().contains("Problem ID : EXAMPLE-1"));
+        assertTrue(exception.getMessage().contains("Where? : Request handler"));
+        assertTrue(exception.getMessage().contains("What? : Cannot parse payload"));
+        assertTrue(exception.getMessage().contains("Why? : Input is malformed"));
+        assertTrue(exception.getMessage().contains("Long description : JSON payload contains invalid field types"));
+        assertTrue(exception.getMessage().contains("Possible solution : Validate payload with JSON schema before parsing"));
+        assertTrue(exception.getMessage().contains("Documentation link : https://example.com/docs/payload"));
+    }
+
+    @Test
+    void builtProblemDoesNotChangeAfterBuilderMutation() {
+        Builder builder = DefaultProblemBuilder.newBuilder()
+                .what("Failure")
+                .addSolution("First solution");
+
+        Problem builtProblem = builder.build();
+        builder.addSolution("Second solution");
+
+        assertEquals(1, builtProblem.getSolutions().size());
+        assertEquals("First solution", builtProblem.getSolutions().get(0));
+    }
+
+    @Test
+    void problemSolutionsListIsUnmodifiable() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .what("Failure")
+                .addSolution("Fix it")
+                .build();
+
+        assertThrows(UnsupportedOperationException.class, () -> problem.getSolutions().add("Another fix"));
+    }
+
+    @Test
+    void buildAsExceptionFailsWhenFactoryReturnsExceptionWithExistingCause() {
+        Throwable existingCause = new IllegalStateException("existing");
+        Throwable newCause = new IllegalArgumentException("new");
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> DefaultProblemBuilder.newBuilder()
+                        .id("EX-CAUSE-1")
+                        .what("Failure")
+                        .cause(newCause)
+                        .buildAsException(message -> {
+                            RuntimeException ex = new RuntimeException(message);
+                            ex.initCause(existingCause);
+                            return ex;
+                        })
+        );
+        assertEquals("Can't overwrite cause with java.lang.IllegalArgumentException: new", error.getMessage());
+    }
+
+    @Test
+    void buildAsExceptionFailsWhenFactoryReturnsNullAndCauseIsPresent() {
+        assertThrows(
+                NullPointerException.class,
+                () -> DefaultProblemBuilder.newBuilder()
+                        .id("EX-NULL-1")
+                        .what("Failure")
+                        .cause(new IllegalArgumentException("new"))
+                        .buildAsException(message -> null)
+        );
+    }
+}

--- a/src/test/java/io/github/xeruvimov/jproblem/builder/StrictProblemBuilderTest.java
+++ b/src/test/java/io/github/xeruvimov/jproblem/builder/StrictProblemBuilderTest.java
@@ -1,0 +1,97 @@
+package io.github.xeruvimov.jproblem.builder;
+
+import io.github.xeruvimov.jproblem.problem.Problem;
+import io.github.xeruvimov.jproblem.problem.ProblemId;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StrictProblemBuilderTest {
+
+    @Test
+    void buildsProblemWithRequiredIdAndWhatUsingStringId() {
+        Problem problem = StrictProblemBuilder.withId("REQ-1")
+                .what("Required fields are present")
+                .build();
+
+        assertEquals("REQ-1", problem.getId().orElseThrow().getId());
+        assertEquals("Required fields are present", problem.getShortDescription());
+    }
+
+    @Test
+    void buildsProblemWithProblemIdInstance() {
+        Problem problem = StrictProblemBuilder.withId(ProblemId.of("REQ-2"))
+                .what("Required fields are present")
+                .build();
+
+        assertEquals("REQ-2", problem.getId().orElseThrow().getId());
+    }
+
+    @Test
+    void buildAsRuntimeExceptionRendersMessage() {
+        RuntimeException exception = StrictProblemBuilder.withId("REQ-3")
+                .what("Cannot process request")
+                .why("Validation failed")
+                .buildAsRuntimeException();
+
+        assertTrue(exception.getMessage().contains("Problem ID : REQ-3"));
+        assertTrue(exception.getMessage().contains("What? : Cannot process request"));
+        assertTrue(exception.getMessage().contains("Why? : Validation failed"));
+    }
+
+    @Test
+    void buildAsExceptionSetsCause() {
+        Throwable rootCause = new IllegalArgumentException("bad input");
+
+        IllegalStateException exception = StrictProblemBuilder.withId("REQ-4")
+                .what("Failed to create entity")
+                .cause(rootCause)
+                .buildAsException(IllegalStateException::new);
+
+        assertSame(rootCause, exception.getCause());
+        assertTrue(exception.getMessage().contains("Problem ID : REQ-4"));
+    }
+
+    @Test
+    void withIdRejectsNullString() {
+        NullPointerException error = assertThrows(
+                NullPointerException.class,
+                () -> StrictProblemBuilder.withId((String) null)
+        );
+        assertEquals("id must not be null", error.getMessage());
+    }
+
+    @Test
+    void withIdRejectsNullProblemId() {
+        NullPointerException error = assertThrows(
+                NullPointerException.class,
+                () -> StrictProblemBuilder.withId((ProblemId) null)
+        );
+        assertEquals("id must not be null", error.getMessage());
+    }
+
+    @Test
+    void withIdAcceptsBlankAndWhitespaceIds() {
+        Problem blank = StrictProblemBuilder.withId("")
+                .what("Blank id")
+                .build();
+        Problem whitespace = StrictProblemBuilder.withId("   ")
+                .what("Whitespace id")
+                .build();
+
+        assertEquals("", blank.getId().orElseThrow().getId());
+        assertEquals("   ", whitespace.getId().orElseThrow().getId());
+    }
+
+    @Test
+    void whatRejectsNullShortDescription() {
+        NullPointerException error = assertThrows(
+                NullPointerException.class,
+                () -> StrictProblemBuilder.withId("REQ-5").what(null)
+        );
+        assertEquals("shortDescription must not be null", error.getMessage());
+    }
+}

--- a/src/test/java/io/github/xeruvimov/jproblem/problem/BaseProblemTest.java
+++ b/src/test/java/io/github/xeruvimov/jproblem/problem/BaseProblemTest.java
@@ -1,0 +1,50 @@
+package io.github.xeruvimov.jproblem.problem;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BaseProblemTest {
+
+    @Test
+    void constructorMakesDefensiveCopyOfSolutions() {
+        List<String> sourceSolutions = new ArrayList<>();
+        sourceSolutions.add("First");
+
+        BaseProblem problem = new BaseProblem(
+                ProblemId.of("BP-1"),
+                "Failure",
+                null,
+                null,
+                sourceSolutions,
+                null,
+                null,
+                null
+        );
+
+        sourceSolutions.add("Second");
+
+        assertEquals(1, problem.getSolutions().size());
+        assertEquals("First", problem.getSolutions().get(0));
+    }
+
+    @Test
+    void returnedSolutionsListIsUnmodifiable() {
+        BaseProblem problem = new BaseProblem(
+                ProblemId.of("BP-2"),
+                "Failure",
+                null,
+                null,
+                List.of("Only"),
+                null,
+                null,
+                null
+        );
+
+        assertThrows(UnsupportedOperationException.class, () -> problem.getSolutions().add("Another"));
+    }
+}

--- a/src/test/java/io/github/xeruvimov/jproblem/render/DefaultTextRenderTest.java
+++ b/src/test/java/io/github/xeruvimov/jproblem/render/DefaultTextRenderTest.java
@@ -1,0 +1,139 @@
+package io.github.xeruvimov.jproblem.render;
+
+import io.github.xeruvimov.jproblem.builder.DefaultProblemBuilder;
+import io.github.xeruvimov.jproblem.problem.Problem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultTextRenderTest {
+
+    @Test
+    void renderShowsSingleSolutionLabelForOneSolution() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .what("Single solution case")
+                .addSolution("Do one thing")
+                .build();
+
+        String rendered = DefaultTextRender.render(problem);
+
+        assertTrue(rendered.contains("Possible solution : Do one thing"));
+    }
+
+    @Test
+    void renderShowsListLabelForMultipleSolutions() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .what("Multiple solutions case")
+                .addSolution("First option")
+                .addSolution("Second option")
+                .build();
+
+        String rendered = DefaultTextRender.render(problem);
+
+        assertTrue(rendered.contains("Possible solutions : "));
+        assertTrue(rendered.contains("    - First option"));
+        assertTrue(rendered.contains("    - Second option"));
+    }
+
+    @Test
+    void compactToSingleLinePreservesSections() {
+        String input = "A problem happened\n\nWhat? : Something failed\nWhy? : Bad input\n\nPossible solutions : \n    - Retry";
+
+        String compacted = DefaultTextRender.compactToSingleLine(input);
+
+        assertEquals(
+                "A problem happened | What? : Something failed Why? : Bad input | Possible solutions : - Retry",
+                compacted
+        );
+    }
+
+    @Test
+    void renderWithOnlyRequiredFieldsDoesNotPrintOptionalSections() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .what("Only required")
+                .build();
+
+        String rendered = DefaultTextRender.render(problem);
+
+        assertEquals("A problem happened\n\nWhat? : Only required", rendered);
+    }
+
+    @Test
+    void renderWithNullHeaderKeepsFormatting() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .what("Header test")
+                .build();
+
+        String rendered = DefaultTextRender.render(null, problem);
+
+        assertEquals("null\n\nWhat? : Header test", rendered);
+    }
+
+    @Test
+    void renderSupportsEmptyAndWhitespaceValues() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .id("  ")
+                .what("")
+                .where(" ")
+                .why("   ")
+                .withLongDescription(" ")
+                .addSolution(" ")
+                .documentedAt(" ")
+                .build();
+
+        String rendered = DefaultTextRender.render(problem);
+
+        assertTrue(rendered.contains("Problem ID :   "));
+        assertTrue(rendered.contains("Where? :  "));
+        assertTrue(rendered.contains("What? : "));
+        assertTrue(rendered.contains("Why? :    "));
+        assertTrue(rendered.contains("Long description :  "));
+        assertTrue(rendered.contains("Possible solution :  "));
+        assertTrue(rendered.contains("Documentation link :  "));
+    }
+
+    @Test
+    void compactToSingleLineReturnsNullForNullInput() {
+        assertEquals(null, DefaultTextRender.compactToSingleLine(null));
+    }
+
+    @Test
+    void compactToSingleLineNormalizesMixedLineEndingsAndWhitespace() {
+        String input = "Header\r\n\r\nWhat? : Failed\t\t\rWhy? : Bad  data\n\n\nPossible solution : Retry";
+
+        String compacted = DefaultTextRender.compactToSingleLine(input);
+
+        assertEquals("Header | What? : Failed Why? : Bad data | Possible solution : Retry", compacted);
+    }
+
+    @Test
+    void renderProducesExactTextForMultipleSolutionsGoldenMaster() {
+        Problem problem = DefaultProblemBuilder.newBuilder()
+                .id("GM-1")
+                .where("Service layer")
+                .what("Cannot execute")
+                .why("Dependency timeout")
+                .withLongDescription("Remote system did not respond in time")
+                .addSolution("Retry request")
+                .addSolution("Increase timeout")
+                .documentedAt("https://example.com/docs/timeouts")
+                .build();
+
+        String rendered = DefaultTextRender.render(problem);
+
+        assertEquals(
+                "A problem happened\n\n" +
+                        "Problem ID : GM-1\n\n" +
+                        "Where? : Service layer\n\n" +
+                        "What? : Cannot execute\n\n" +
+                        "Why? : Dependency timeout\n\n" +
+                        "Long description : Remote system did not respond in time\n\n" +
+                        "Possible solutions : \n" +
+                        "    - Retry request\n" +
+                        "    - Increase timeout\n\n" +
+                        "Documentation link : https://example.com/docs/timeouts",
+                rendered
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a safer and more ergonomic API for building `Problem` objects, improves rendering behavior for HTTP/JSON use-cases, expands test coverage, and updates project documentation and release workflow.

## Main Changes

1. Added a new type-safe staged API: `StrictProblemBuilder`
- Enforces required fields at compile time:
  - `id` is required
  - `what` is required
- Supports:
  - `build()`
  - `buildAsRuntimeException()`
  - `buildAsException(...)`

2. Improved ID ergonomics while keeping backward compatibility
- Added `Builder.id(String)` default overload.
- Added `ProblemId.of(String)` factory.
- Existing lambda-style `id(() -> "...")` remains fully supported.

3. Added single-line compaction for HTTP/JSON responses
- New method: `DefaultTextRender.compactToSingleLine(String)`.
- Normalizes multiline rendered messages into a compact single line with section separators.

4. Strengthened immutability and snapshot behavior
- `BaseProblem` now defensively copies solutions.
- Prevents accidental mutation from builder reuse / external list modification.

5. Added comprehensive test coverage
- Added JUnit 5 dependency in `pom.xml`.
- Added/updated tests for:
  - legacy + strict builder flows
  - rendering format and edge cases
  - single-line compaction behavior
  - exception factory/cause behavior
  - immutability/defensive copy guarantees

6. Updated docs and metadata
- Updated README with:
  - new recommended `StrictProblemBuilder` usage
  - legacy API section
  - single-line message guidance for HTTP/JSON
  - dependency version update to `1.1.0`
- Added Javadocs across public API, including guidance that the legacy builder remains supported but `StrictProblemBuilder` is preferred for new code.

7. Release pipeline improvement
- Updated Maven publish workflow to run tests before deploy.
- Publish step still uses `-DskipTests` to avoid duplicate test execution after the explicit test step.

8. Misc
- Added `.idea/` to `.gitignore`.

## Version
- Bumped project version from `1.0.2` to `1.1.0`.